### PR TITLE
fixed to use (extended) grapheme clusters

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,13 +1,14 @@
 <?php
 //Why would we ever need to use an image generation library? All done in less than 40 lines of code...
+mb_internal_encoding("UTF-8");
 header('Content-type: image/svg+xml');
 $name = $_GET["name"] ?? "O";
 $length = $_GET["length"] ?? 2;
-$letters = substr($name, 0, $length);
-if ($length > 1 && strlen($name) > 2 && strpos($name, " ") < strlen($name)) {
-    $letters = substr($name, 0, 1) . substr($name, strpos($name, " ") + 1, 1);
+$letters = grapheme_substr($name, 0, $length);
+if ($length > 1 && grapheme_strlen($name) > 2 && grapheme_strpos($name, " ") < grapheme_strlen($name)) {
+    $letters = grapheme_substr($name, 0, 1) . grapheme_substr($name, grapheme_strpos($name, " ") + 1, 1);
 } else {
-    $letters = substr($name, 0, $length);
+    $letters = grapheme_substr($name, 0, $length);
 }
 if (empty($_GET["background"])) {
     //If not set or defined, pick a random sexy color.
@@ -23,9 +24,9 @@ if (empty($_GET["color"])) {
     $color = "#".$_GET["color"];
 }
 if (empty($_GET["caps"]) || $_GET["caps"] == "1") {
-    $letters = strtoupper($letters);
+    $letters = mb_strtoupper($letters);
 } else if ($_GET["caps"] == "2") {
-    $letters = strtolower($letters);
+    $letters = mb_strtolower($letters);
 }
 $width = $_GET["width"] ?? "500";
 $height = $_GET["height"] ?? "500";


### PR DESCRIPTION
Previously, if a user attempted to input a non-ASCII name, the avatar generator would fail in all sorts of ways (see [here](https://www.reddit.com/r/opensource/comments/cb7jod/a_ridiculously_simple_avatar_generator_with/etea3pu/)).

This simple fix makes it so instead of slicing the string by bytes, it slices by "grapheme clusters", broadly, user-perceived characters. These are defined in Unicode's [UAX #29](https://unicode.org/reports/tr29/).

Note that one other possibility would be to slice the string by Unicode code points (using the `mb_substr()` functions, etc.). This would work in *some* cases, but results in strange behavior like "ṗ" being treated as one character, but "p̣" being treated as two characters. Using grapheme clusters solves this problem and treats both as a single character, just how a user would imagine them to be. For more details, see [this essay](https://manishearth.github.io/blog/2017/01/14/stop-ascribing-meaning-to-unicode-code-points/).

Note: To get this to work on my machine, I had to install the `php7.2-mbstring` and `php7.2-intl` packages. If they aren't already installed on your server, you might need to in order to get these functions to work.