### PR TITLE
Updated documentation of caps default value

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
                             <td>caps</td>
                             <td>Capitalization of the letter(s). 3 for leaving such as provided, 2 for all lowercase or
                                 1 for all uppercase.</td>
-                            <td>1</td>
+                            <td>3</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
The default value of "caps" seems to be 3, not 1 as stated in the documentation.

Without defining "caps" as a query parameter, expected according to the documentation would be to print it as uppercase, but the result is actually "as you leave it", meaning the default value is actually "3".
https://avatar.oxro.io/avatar.svg?name=eddie&background=ff6b6b&bold=true